### PR TITLE
Check for presence of project-wide (ext) Gradle configuration properties

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,12 +13,20 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
-android {
-    compileSdkVersion 27
+def DEFAULT_COMPILE_SDK_VERSION             = 27
+def DEFAULT_BUILD_TOOLS_VERSION             = "27.0.3"
+def DEFAULT_TARGET_SDK_VERSION              = 27
+def DEFAULT_FIREBASE_VERSION                = "16.0.1"
+def DEFAULT_SUPPORT_LIB_VERSION             = "27.0.0"
 
+
+
+android {
+    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"
     }
@@ -39,8 +47,10 @@ repositories {
 
 dependencies {
     //noinspection GradleCompatible
-    implementation 'com.android.support:appcompat-v7:27.0.0'
+    def firebaseVersion = rootProject.hasProperty('firebaseVersion')  ? rootProject.firebaseVersion : DEFAULT_FIREBASE_VERSION
+    def supportLibVersion =  rootProject.hasProperty('supportLibVersion')  ? rootProject.supportLibVersion : DEFAULT_SUPPORT_LIB_VERSION
+    implementation "com.android.support:appcompat-v7:$supportLibVersion"
     implementation "com.facebook.react:react-native:+"
-    implementation 'com.google.firebase:firebase-core:+'
-    implementation "com.google.firebase:firebase-auth:+"
+    implementation "com.google.firebase:firebase-core:$firebaseVersion"
+    implementation "com.google.firebase:firebase-auth:$firebaseVersion"
 }


### PR DESCRIPTION
Root project dependency resolution for Gradle configuration properties `compileSdkVersion`, `targetSdkVersion`, `buildToolsVersion`, `supportLibVersion`, `firebaseVersion`. 
This provides a better mechanism for aligning the requirements of the module with that of the host project.